### PR TITLE
Parkway as Py, Pky

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -873,6 +873,7 @@
     [
         "Py",
         "Pky",
+        "Pw",
         "Pwy",
         "Pkwy",
         "Parkway"

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -871,6 +871,8 @@
         "Pathway"
     ],
     [
+        "Py",
+        "Pky",
         "Pwy",
         "Pkwy",
         "Parkway"


### PR DESCRIPTION
“Pky.” is a common abbreviation for “parkway” used throughout the United States and officially by the [USPS](http://pe.usps.gov/text/pub28/28apc_002.htm). “Py.” is much rarer; recently San José posted a sign bearing this abbreviation on [this traffic light](http://www.openstreetmap.org/node/245919607).