### PR TITLE
Ensure regexes are valid

### DIFF
--- a/test.js
+++ b/test.js
@@ -46,6 +46,10 @@ tape((t) => {
 
     t.equals(typeof tokens.global, 'object');
 
+    for (let token in tokens.global) {
+        t.ok(new RegExp(token))
+    }
+
     Object.keys(tokens).forEach((token) => {
         if (token === 'global') return;
 


### PR DESCRIPTION
Test each global regex to ensure that an invalid regex causes failed tests.

Encountered this yesterday when migrating some new regexes into this repo that a newline when copying messed up the regex but still passed tests.

cc/ @yhahn 