### PR TITLE
Add Spanish abbreviations: de/del/de la

### DIFF
--- a/tokens/es.json
+++ b/tokens/es.json
@@ -259,6 +259,15 @@
         "Diseminado"
     ],
     [
+        "de"
+    ],
+    [
+        "del"
+    ],
+    [
+        "de la"
+    ],
+    [
         "Edifc",
         "Edificio"
     ],


### PR DESCRIPTION
These are not abbreviated, and were not being tokenized in mapbox-places-address. 
- added ignored abbreviations for de/del/de la in es