### PR TITLE
Remove the "Bvd" abbreviation for boulevard

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -172,7 +172,6 @@
         "Bottom"
     ],
     [
-        "Bvd",
         "Blvd",
         "Boulevard"
     ],


### PR DESCRIPTION
Gettin' a release out with @apendleton's fix.