### PR TITLE
remove Bis:B abbreviation from fr token list

### DIFF
--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -112,10 +112,6 @@
         "Avenue"
     ],
     [
-        "B",
-        "Bis"
-    ],
-    [
         "Bat",
         "Batîment"
     ],


### PR DESCRIPTION
"Bis" is used in French addresses to indicate a sub-unit like a basement or semi-attached area, not unlike `221B Baker Street` in English.

This abbreviation is of relatively minor importance, and leads to a number of false positives. Removing will lead to better behavior on net.