### PR TITLE
Add complex replacements for umlauts in german

### DIFF
--- a/tokens/de.json
+++ b/tokens/de.json
@@ -122,5 +122,17 @@
     [
         "z",
         "zum"
+    ],
+    [
+        "ä",
+        {"skipBoundaries": true, "skipDiacriticStripping": true, "text": "ae"}
+    ],
+    [
+        "ö",
+        {"skipBoundaries": true, "skipDiacriticStripping": true, "text": "oe"}
+    ],
+    [
+        "ü",
+        {"skipBoundaries": true, "skipDiacriticStripping": true, "text": "ue"}
     ]
 ]


### PR DESCRIPTION
This is kind of an odd PR, but it adds a couple of extra replacements for German to normalize umlauts that are represented in a new format being added to carmen to control whether or not token replacements have to be bounded by word boundaries (typically they do, but these don't).