### PR TITLE
remove church, school, and station token replacers

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -1035,7 +1035,6 @@
         "Street"
     ],
     [
-        "Sta",
         "Stn",
         "Station"
     ],

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -206,8 +206,7 @@
     ],
     [
         "Ch",
-        "Chase",
-        "Church"
+        "Chase"
     ],
     [
         "Chk",
@@ -970,10 +969,6 @@
     [
         "Sbwy",
         "Subway"
-    ],
-    [
-        "Sch",
-        "School"
     ],
     [
         "SE",


### PR DESCRIPTION
Too many false matches, these make it difficult to search by category.