### PR TITLE
add boul, aut for boulevard, autoroute

### DIFF
--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -85,6 +85,7 @@
     ],
     [
         "A",
+        "Aut",
         "Autoroute"
     ],
     [
@@ -117,6 +118,8 @@
     ],
     [
         "Bd",
+        "Boul",
+        "Blvd",
         "Boulevard"
     ],
     [


### PR DESCRIPTION
I ran into these missing tokens while loading address data from Canadian sources.