### PR TITLE
US unit number stripping

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2868,69 +2868,9 @@
     {
         "tokens": [
             "",
-            "Suite [0-9]+"
+            "(?:suite|ste) #?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)"
         ],
-        "full": "Suite [0-9]+",
-        "canonical": "",
-        "spanBoundaries": 1,
-        "onlyLayers": ["address"],
-        "type": "unit",
-        "regex": true
-    },
-    {
-        "tokens": [
-            "",
-            "Suite [0-9]+-[0-9]+"
-        ],
-        "full": "Suite [0-9]+-[0-9]+",
-        "canonical": "",
-        "spanBoundaries": 1,
-        "onlyLayers": ["address"],
-        "type": "unit",
-        "regex": true
-    },
-    {
-        "tokens": [
-            "",
-            "Suite [0-9]+[a-z]"
-        ],
-        "full": "Suite [0-9]+[a-z]",
-        "canonical": "",
-        "spanBoundaries": 1,
-        "onlyLayers": ["address"],
-        "type": "unit",
-        "regex": true
-    },
-    {
-        "tokens": [
-            "",
-            "Suite [a-z]"
-        ],
-        "full": "Suite [a-z]",
-        "canonical": "",
-        "spanBoundaries": 1,
-        "onlyLayers": ["address"],
-        "type": "unit",
-        "regex": true
-    },
-    {
-        "tokens": [
-            "",
-            "STE [0-9]+"
-        ],
-        "full": "STE [0-9]+",
-        "canonical": "",
-        "spanBoundaries": 1,
-        "onlyLayers": ["address"],
-        "type": "unit",
-        "regex": true
-    },
-    {
-        "tokens": [
-            "",
-            "STE [a-z]"
-        ],
-        "full": "STE [a-z]",
+        "full": "(?:suite|ste) #?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)",
         "canonical": "",
         "spanBoundaries": 1,
         "onlyLayers": ["address"],
@@ -2982,5 +2922,57 @@
         "full": "N.T.",
         "canonical": "NT",
         "onlyCountries": ["hk"]
+    },
+    {
+        "tokens": [
+            "",
+            "(?:apartment|apt|bldg|building|rm|room|unit) #?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)"
+        ],
+        "canonical": "",
+        "full": "(?:apartment|apt|bldg|building|rm|room|unit) #?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)",
+        "regex": true,
+        "spanBoundaries": 1,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["us"],
+        "type": "unit"
+    },
+    {
+        "tokens": [
+            "",
+            "(?:floor|fl) #?\\d{1,3}"
+        ],
+        "canonical": "",
+        "full": "(?:floor|fl) #?\\d{1,3}",
+        "regex": true,
+        "spanBoundaries": 1,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["us"],
+        "type": "unit"
+    },
+    {
+        "tokens": [
+            "",
+            "\\d{1,3}(?:st|nd|rd|th) (?:floor|fl)"
+        ],
+        "canonical": "",
+        "full": "\\d{1,3}(?:st|nd|rd|th) (?:floor|fl)",
+        "regex": true,
+        "spanBoundaries": 1,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["us"],
+        "type": "unit"
+    },
+    {
+        "tokens": [
+            "$1",
+            "((?!apartment|apt|bldg|building|rm|room|unit|fl|floor|ste|suite)[a-z]{2,}) # ?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)"
+        ],
+        "canonical": "$1",
+        "full": "((?!apartment|apt|bldg|building|rm|room|unit|fl|floor|ste|suite)[a-z]{2,}) # ?(?:[A-Z]|\\d+|[A-Z]\\d+|\\d+[A-Z]|\\d+-\\d+[A-Z]?)",
+        "regex": true,
+        "spanBoundaries": 1,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["us"],
+        "type": "unit"
     }
 ]


### PR DESCRIPTION
This PR leverages some recent work allowing for more expressive replacements to add a bunch of new token replacements targeted specifically at stripping unit numbers from addresses. For now, most of these changes are scoped to the US out of an abundance of caution.

Concretely, the PR adds support for stripping unit numbers of the formats:
* one of the designators `apartment`, `apt`, `bldg`, `building`, `rm`, `room`, and `unit` followed optionally by a pound sign followed by a unit number of any of the formats `[number]`, `[single letter]`, `[number][single letter]`, `[single letter][number]`, `[number]-[number]`, `[number]/[number]`, `[number]-[number][letter]`
* two special formats specifically for floor numbers: `[number][ordinal]` followed by `fl` or `floor`, and `fl` or `floor` followed by an up-to-three-digit number (to avoid accidentally clobbering combinations of the state abbreviation for Florida plus a postcode
* suite numbers consisting of `ste` or `suite` followed optionally by a pound sign followed by any of the number formats in the first entry; note that these *replace* existing STE/Suite rules which were already in place, to reduce the total number of replacements (they were needlessly split out before) and to broaden the set of supported number formats slightly so that it matches the number formats of the new entries; because these replacements were previously not country-scoped, the new ones aren't either, for suite/ste only
* `#` plus any of the number formats listed in the first bullet point, following a word that *isn't* `apartment`, `apt`, `bldg`, `building`, `rm`, `room`, `unit`, `ste`, `suite`, `fl`, or `floor` -- these replacements can't be at the beginning of a query (to avoid clobbering house numbers by mistake) but leave the leading word in place, unlike the ones designed for specific designators. Note that this uses a negative lookahead group, so it's a little funky looking.

cc @mapbox/search 