### PR TITLE
Add new token type enum, make public struct more accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,18 +56,18 @@ struct InToken {
 }
 
 pub struct Token {
-    tokens: Vec<String>,
-    full: BasicToken,
-    canonical: String,
-    note: Option<String>,
-    only_countries: Option<Vec<String>>,
-    only_layers: Option<Vec<String>>,
-    prefer_full: bool,
-    regex: bool,
-    skip_boundaries: bool,
-    skip_diacritic_stripping: bool,
-    span_boundaries: Option<u8>,
-    token_type: Option<String>,
+    pub tokens: Vec<String>,
+    pub full: BasicToken,
+    pub canonical: String,
+    pub note: Option<String>,
+    pub only_countries: Option<Vec<String>>,
+    pub only_layers: Option<Vec<String>>,
+    pub prefer_full: bool,
+    pub regex: bool,
+    pub skip_boundaries: bool,
+    pub skip_diacritic_stripping: bool,
+    pub span_boundaries: Option<u8>,
+    pub token_type: Option<String>,
 }
 
 impl Token {


### PR DESCRIPTION
## Context

As part of downstream work, makes several improvements to the Rust library to make structs more accessible (`pub`) and variants tightly defined (adding `enum`s).

## Summary of changes
- [x] adds more Error variants to handle unsupported token types and errors generating regexes from fancy-regex
- [x] adds new enum `Type` (may rename) to capture supported token type variants (instead of storing as a string/testing manually) and a method for converting to a `Type` enum
- [x] makes all fields on the `Token` struct public

## Next steps
I'll likely leave this PR open as work moves downstream in case I need to make any additional changes. One problem I'm consistently running into is the lack of traits implemented on external fancy-regex types, particularly `PartialEq` and `Debug`. Per [the docs](https://doc.rust-lang.org/book/ch10-02-traits.html), you can’t implement external traits on external types. I'll eventually need to implement one of the work arounds suggested in https://users.rust-lang.org/t/deriving-external-traits-on-external-structs/18198 to be able to integrate fancy-regex types with downstream/external types.

cc @ingalls 
