### PR TITLE
Adds 'way' type to road token

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2197,7 +2197,8 @@
             "Road"
         ],
         "full": "Road",
-        "canonical": "Rd"
+        "canonical": "Rd",
+        "type": "way"
     },
     {
         "tokens": [


### PR DESCRIPTION
## Context

The `road` token in `en` should be categorized as a `way` type.

cc @mapbox/search 