### PR TITLE
Use core regex lib, filter lookaround regexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,36 +12,12 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bit-set"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "fancy-regex"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
 dependencies = [
  "alphanumeric-sort 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -53,26 +29,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
-version = "0.2.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memchr"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -97,19 +55,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.6"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,21 +140,15 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum alphanumeric-sort 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7cd2580c95c654d681db0194a310af67a293f5e1c8bafa5b35b63269c4665a39"
-"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
-"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0decc1ae13c103787f0a543307ee8dac9deceecdb463aceaff35bbb7068d86c2"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
-"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
+"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 alphanumeric-sort = "1.0.6"
-fancy-regex = "0.1.0"
 lazy_static = "1.3.0"
+regex = "1.1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,26 @@ impl PartialEq for Token {
 }
 
 impl Token {
+    fn new(full: String, canonical: String, token_type: Option<TokenType>, regex: bool) -> Result<Self, Error> {
+        Ok(Token {
+            regex: match regex {
+                true => Some(Regex::new(&full)?),
+                false => None
+            },
+            tokens: vec![canonical.clone(), full.clone()],
+            full: full,
+            canonical: canonical,
+            note: None,
+            only_countries: None,
+            only_layers: None,
+            prefer_full: false,
+            skip_boundaries: false,
+            skip_diacritic_stripping: false,
+            span_boundaries: None,
+            token_type: token_type,
+        })
+    }
+
     fn from_input(input: InToken) -> Result<Self, Error> {
         Ok(Token {
             regex: match input.regex {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,36 @@ pub struct Token {
     pub token_type: Option<TokenType>,
 }
 
+impl PartialEq for Token {
+    fn eq(&self, other: &Self) -> bool {
+
+        // do not check that self.regex == other.regex
+        // can't derive PartialEq trait on regex::Regex
+        // these values are created from the full property which is checked
+        let self_regex = match &self.regex {
+            Some(r) => Some(r.as_str()),
+            None => None
+        };
+        let other_regex = match &other.regex {
+            Some(r) => Some(r.as_str()),
+            None => None
+        };
+
+        self_regex == other_regex &&
+        self.tokens == other.tokens &&
+        self.full == other.full &&
+        self.canonical == other.canonical &&
+        self.note == other.note &&
+        self.only_countries == other.only_countries &&
+        self.only_layers == other.only_layers &&
+        self.prefer_full == other.prefer_full &&
+        self.skip_boundaries == other.skip_boundaries &&
+        self.skip_diacritic_stripping == other.skip_diacritic_stripping &&
+        self.span_boundaries == other.span_boundaries &&
+        self.token_type == other.token_type
+    }
+}
+
 impl Token {
     fn from_input(input: InToken) -> Result<Self, Error> {
         Ok(Token {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl PartialEq for Token {
 }
 
 impl Token {
-    fn new(full: String, canonical: String, token_type: Option<TokenType>, regex: bool) -> Result<Self, Error> {
+    pub fn new(full: String, canonical: String, token_type: Option<TokenType>, regex: bool) -> Result<Self, Error> {
         Ok(Token {
             regex: match regex {
                 true => Some(Regex::new(&full)?),


### PR DESCRIPTION
## Context

As noted in https://github.com/mapbox/geocoder-abbreviations/pull/49#issue-275492546, the fancy_regex crate we use to create Regex replacements doesn't support key traits such as `Debug` and `PartialEq`. For now, we're going to filter out all regexes that use lookarounds (only https://github.com/mapbox/geocoder-abbreviations/blob/master/tokens/en.json#L2967-L2977) and use Rust's core regex crate rather than fancy_regex. In the future, we'll either modify current regexes to no longer use lookarounds or go back to fancy regex and build custom traits as needed.

## Summary of changes
- [ ] use core regex crate rather than fancy_regex
- [ ] make `regex` property on `Token` enum an `Option<Regex>` rather than using a `bool` and a custom enum
- [ ] removes custom enum `Replacer`
- [ ] filter and warn on unsupported lookaround regexes

cc @miccolis @ingalls @samely 