### PR TITLE
Make 'Place' a 'way' type

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2026,7 +2026,8 @@
             "Place"
         ],
         "full": "Place",
-        "canonical": "Pl"
+        "canonical": "Pl",
+        "type": "way"
     },
     {
         "tokens": [


### PR DESCRIPTION
## Context

We forgot to categorize `Place` as a `way` type in our abbreviations.

cc @miccolis @ingalls @samely @mattciferri 