### PR TITLE
Farm-To-Market & Ranch-To-Market

### DIFF
--- a/tokens/en.json
+++ b/tokens/en.json
@@ -1193,11 +1193,11 @@
     },
     {
         "tokens": [
-            "Fm",
-            "Farm"
+            "FM",
+            "Farm-To-Market"
         ],
-        "full": "Farm",
-        "canonical": "Fm"
+        "full": "Farm-To-Market",
+        "canonical": "FM"
     },
     {
         "tokens": [
@@ -2245,11 +2245,11 @@
     },
     {
         "tokens": [
-            "Rnch",
-            "Ranch"
+            "RM",
+            "Ranch-To-Market"
         ],
-        "full": "Ranch",
-        "canonical": "Rnch"
+        "full": "Ranch-To-Market",
+        "canonical": "RM"
     },
     {
         "tokens": [


### PR DESCRIPTION
We initially added the `farm/fm` as a stopgap because we didn't support cardinality changing tokens. 

We support cardinality changing tokens now and should update these tokens to their original intent

Documentation: https://en.wikipedia.org/wiki/Farm-to-market_road

Ref: https://github.com/mapbox/geocoder-feedback/issues/3005

Customer Pain: https://docs.google.com/spreadsheets/d/1tvVu-mDaeDWaQOIVujuzZxd4oNSgU7FmRK7904xjirI/edit#gid=0