### PR TITLE
Handle missing ordinals

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ how to employ the token list in question. They are:
     be assumed not to have been escaped for use in regular expression** (e.g.,
     periods are just periods), and consumers who want to use them in regular
     expressions should perform their own escaping before doing so.
+* **reduceRelevance (boolean):** an indication that the replacement will be indexed
+    with a reduced relevance.
 * **skipBoundaries (boolean):** an indication that the replacement shouldn't
     have to match at a word boundary. Absence should be interpreted as `false`.
 * **skipDiacriticStripping (boolean):** an indication that the replacement

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,7 @@ tape((t) => {
                 onlyLayers: { type: 'array', required: false, allowed: [ 'address' ] },
                 preferFull: { type: 'boolean', required: false },
                 regex: { type: 'boolean', required: false },
+                reduceRelevance: { type: 'boolean', required: false },
                 skipBoundaries: { type: 'boolean', required: false },
                 skipDiacriticStripping: { type: 'boolean', required: false },
                 spanBoundaries: { type: 'number', required: false },

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2976,5 +2976,18 @@
         "onlyLayers": ["address"],
         "onlyCountries": ["us"],
         "type": "unit"
+    },
+    {
+        "tokens": [
+            "$1",
+            "([0-9]+)(?:st|nd|rd|th)"
+        ],
+        "canonical": "$1",
+        "full": "([0-9]+)(?:st|nd|rd|th)",
+        "regex": true,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["us"],
+        "reduceRelevance": true
+
     }
 ]


### PR DESCRIPTION
### Context 
As a part of being able to handle missing ordinals in queries, this PR adds token replacement for  dropping ordinals while indexing. It adds a new property `reduceRelevance` which implies that we only perform the token replacement during index time and reduce the relevance and doesn't apply the token replacement during query time. 

### What it adds
- [x] ordinal dropping token replacement to `en.json`
- [x] reduceRelevance property to tests

### Next steps 
- [x] Add reduceRelevance property to README.md
- [x] Review 
- [ ] Merge

cc @mapbox/search 