### PR TITLE
Remove unnecessary German tokens

### DIFF
--- a/test/fixtures/de-advanced.json
+++ b/test/fixtures/de-advanced.json
@@ -1,1 +1,162 @@
-[{"tokens":["auf","a.d.","a.d"],"full":"a.d.","canonical":"auf","note":"translates to 'on the'"},{"tokens":["auf","auf der","a d"],"full":"auf der","canonical":"auf","spanBoundaries":1,"note":"translates to 'on the'; same as above, but this group contains two-token phrases"},{"tokens":["a","am","an","a.d.","a.d"],"full":"an der","canonical":"a","note":"translates to 'at the'"},{"tokens":["a","an der","a d"],"full":"an der","canonical":"a","spanBoundaries":1,"note":"translates to 'at the'; same as above, but this group contains two-token phrases"},{"tokens":["i","in","im","i.d.","i.d"],"full":"in der","canonical":"i","note":"translates to 'in the'"},{"tokens":["i","in der","i d"],"full":"in der","canonical":"i","spanBoundaries":1,"note":"translates to 'in the'; same as above, but this group contains two-token phrases"},{"tokens":["Bf","Bhf","Bahnhof","Bahnhofstr","Bahnhofstraße"],"full":"Bahnhof","canonical":"Bf"},{"tokens":["bg","berg","bergstr","bergstraße"],"full":"berg","canonical":"bg"},{"tokens":["bg","burg"],"full":"burg","canonical":"bg"},{"tokens":["Br","Brücke"],"full":"Brücke","canonical":"Br","onlyLayers":["address"],"note":"translates to 'bridge'"},{"tokens":["Ch","Chaussee"],"full":"Chaussee","canonical":"Ch","onlyLayers":["address"],"note":"translates to 'highway'","type":"way"},{"tokens":["D","Damm"],"full":"Damm","canonical":"D"},{"tokens":["d","der"],"full":"der","canonical":"d"},{"tokens":["df","dorf","dorfstr","dorfstraße"],"full":"dorf","canonical":"df"},{"tokens":["Dr","Doktor"],"full":"Doktor","canonical":"Dr"},{"tokens":["G","Gasse"],"full":"Gasse","canonical":"G","onlyLayers":["address"],"note":"translates to 'alley'","type":"way"},{"tokens":["Gr","Große"],"full":"Große","canonical":"Gr"},{"tokens":["Gr","Großer"],"full":"Großer","canonical":"Gr"},{"tokens":["Gr","Großes"],"full":"Großes","canonical":"Gr"},{"tokens":["Hbf","Hauptstr","Hauptstraße","Hauptbahnhof"],"full":"Hauptbahnhof","canonical":"Hbf"},{"tokens":["Hl","Heiligen"],"full":"Heiligen","canonical":"Hl"},{"tokens":["Kl","Kleine"],"full":"Kleine","canonical":"Kl"},{"tokens":["Kl","Kleiner"],"full":"Kleiner","canonical":"Kl"},{"tokens":["Kl","Kleines"],"full":"Kleines","canonical":"Kl"},{"tokens":["Kr","Krs","Kreis"],"full":"Kreis","canonical":"Kr","onlyLayers":["address"],"note":"translates to 'circle'","type":"way"},{"tokens":["Lk","Lkr","Lkrs","Landkrs","Landkreis"],"full":"Landkreis","canonical":"Lk"},{"tokens":["o","ob"],"full":"ob","canonical":"o"},{"tokens":["Ob","Obere"],"full":"Obere","canonical":"Ob"},{"tokens":["Ob","Oberer"],"full":"Oberer","canonical":"Ob"},{"tokens":["Ob","Oberes"],"full":"Oberes","canonical":"Ob"},{"tokens":["Pl","Platz"],"full":"Platz","canonical":"Pl","type":"way"},{"tokens":["Rh","Rhein"],"full":"Rhein","canonical":"Rh"},{"tokens":["Ring","Ringstr","Ringstraße"],"full":"Ringstr","canonical":"Ring"},{"tokens":["St","Sankt"],"full":"Sankt","canonical":"St","note":"Reference to a saint"},{"tokens":["Str","Straße","Strasse"],"full":"Strasse","canonical":"Str","note":"translates to 'street'","type":"way"},{"tokens":["U","Untere"],"full":"Untere","canonical":"U"},{"tokens":["U","Unterer"],"full":"Unterer","canonical":"U"},{"tokens":["U","Unteres"],"full":"Unteres","canonical":"U"},{"tokens":["v","von"],"full":"von","canonical":"v"},{"tokens":["Wg","Weg"],"full":"Weg","canonical":"Wg","onlyLayers":["address"],"note":"translates to 'path'","type":"way"},{"tokens":["z","zum"],"full":"zum","canonical":"z"},{"tokens":["ä","ae"],"skipBoundaries":true,"full":"ä","skipDiacriticStripping":true,"canonical":"ae"},{"tokens":["ö","oe"],"skipBoundaries":true,"full":"ö","skipDiacriticStripping":true,"canonical":"oe"},{"tokens":["ü","ue"],"skipBoundaries":true,"full":"ü","skipDiacriticStripping":true,"canonical":"ue"},{"tokens":["$1 str","([^ ]+)(strasse|str|straße)"],"full":"([^ ]+)(strasse|str|straße)","canonical":"$1 str","regex":true,"skipDiacriticStripping":true,"spanBoundaries":0,"onlyUseWhile":["indexing","querying"]}]
+[
+  {
+    "tokens": ["auf", "a.d.", "a.d"],
+    "full": "a.d.",
+    "canonical": "auf",
+    "note": "translates to 'on the'"
+  },
+  {
+    "tokens": ["auf", "auf der", "a d"],
+    "full": "auf der",
+    "canonical": "auf",
+    "spanBoundaries": 1,
+    "note": "translates to 'on the'; same as above, but this group contains two-token phrases"
+  },
+  {
+    "tokens": ["a", "am", "an", "a.d.", "a.d"],
+    "full": "an der",
+    "canonical": "a",
+    "note": "translates to 'at the'"
+  },
+  {
+    "tokens": ["a", "an der", "a d"],
+    "full": "an der",
+    "canonical": "a",
+    "spanBoundaries": 1,
+    "note": "translates to 'at the'; same as above, but this group contains two-token phrases"
+  },
+  {
+    "tokens": ["i", "in", "im", "i.d.", "i.d"],
+    "full": "in der",
+    "canonical": "i",
+    "note": "translates to 'in the'"
+  },
+  {
+    "tokens": ["i", "in der", "i d"],
+    "full": "in der",
+    "canonical": "i",
+    "spanBoundaries": 1,
+    "note": "translates to 'in the'; same as above, but this group contains two-token phrases"
+  },
+  { "tokens": ["Bf", "Bhf", "Bahnhof"], "full": "Bahnhof", "canonical": "Bf" },
+  { "tokens": ["bg", "berg"], "full": "berg", "canonical": "bg" },
+  { "tokens": ["bg", "burg"], "full": "burg", "canonical": "bg" },
+  {
+    "tokens": ["Br", "Brücke"],
+    "full": "Brücke",
+    "canonical": "Br",
+    "onlyLayers": ["address"],
+    "note": "translates to 'bridge'"
+  },
+  {
+    "tokens": ["Ch", "Chaussee"],
+    "full": "Chaussee",
+    "canonical": "Ch",
+    "onlyLayers": ["address"],
+    "note": "translates to 'highway'",
+    "type": "way"
+  },
+  { "tokens": ["D", "Damm"], "full": "Damm", "canonical": "D" },
+  { "tokens": ["d", "der"], "full": "der", "canonical": "d" },
+  { "tokens": ["df", "dorf"], "full": "dorf", "canonical": "df" },
+  { "tokens": ["Dr", "Doktor"], "full": "Doktor", "canonical": "Dr" },
+  {
+    "tokens": ["G", "Gasse"],
+    "full": "Gasse",
+    "canonical": "G",
+    "onlyLayers": ["address"],
+    "note": "translates to 'alley'",
+    "type": "way"
+  },
+  { "tokens": ["Gr", "Große"], "full": "Große", "canonical": "Gr" },
+  { "tokens": ["Gr", "Großer"], "full": "Großer", "canonical": "Gr" },
+  { "tokens": ["Gr", "Großes"], "full": "Großes", "canonical": "Gr" },
+  {
+    "tokens": ["Hbf", "Hauptbahnhof"],
+    "full": "Hauptbahnhof",
+    "canonical": "Hbf"
+  },
+  { "tokens": ["Hl", "Heiligen"], "full": "Heiligen", "canonical": "Hl" },
+  { "tokens": ["Kl", "Kleine"], "full": "Kleine", "canonical": "Kl" },
+  { "tokens": ["Kl", "Kleiner"], "full": "Kleiner", "canonical": "Kl" },
+  { "tokens": ["Kl", "Kleines"], "full": "Kleines", "canonical": "Kl" },
+  {
+    "tokens": ["Kr", "Krs", "Kreis"],
+    "full": "Kreis",
+    "canonical": "Kr",
+    "onlyLayers": ["address"],
+    "note": "translates to 'circle'",
+    "type": "way"
+  },
+  {
+    "tokens": ["Lk", "Lkr", "Lkrs", "Landkrs", "Landkreis"],
+    "full": "Landkreis",
+    "canonical": "Lk"
+  },
+  { "tokens": ["o", "ob"], "full": "ob", "canonical": "o" },
+  { "tokens": ["Ob", "Obere"], "full": "Obere", "canonical": "Ob" },
+  { "tokens": ["Ob", "Oberer"], "full": "Oberer", "canonical": "Ob" },
+  { "tokens": ["Ob", "Oberes"], "full": "Oberes", "canonical": "Ob" },
+  {
+    "tokens": ["Pl", "Platz"],
+    "full": "Platz",
+    "canonical": "Pl",
+    "type": "way"
+  },
+  { "tokens": ["Rh", "Rhein"], "full": "Rhein", "canonical": "Rh" },
+  {
+    "tokens": ["St", "Sankt"],
+    "full": "Sankt",
+    "canonical": "St",
+    "note": "Reference to a saint"
+  },
+  {
+    "tokens": ["Str", "Straße", "Strasse"],
+    "full": "Strasse",
+    "canonical": "Str",
+    "note": "translates to 'street'",
+    "type": "way"
+  },
+  { "tokens": ["U", "Untere"], "full": "Untere", "canonical": "U" },
+  { "tokens": ["U", "Unterer"], "full": "Unterer", "canonical": "U" },
+  { "tokens": ["U", "Unteres"], "full": "Unteres", "canonical": "U" },
+  { "tokens": ["v", "von"], "full": "von", "canonical": "v" },
+  {
+    "tokens": ["Wg", "Weg"],
+    "full": "Weg",
+    "canonical": "Wg",
+    "onlyLayers": ["address"],
+    "note": "translates to 'path'",
+    "type": "way"
+  },
+  { "tokens": ["z", "zum"], "full": "zum", "canonical": "z" },
+  {
+    "tokens": ["ä", "ae"],
+    "skipBoundaries": true,
+    "full": "ä",
+    "skipDiacriticStripping": true,
+    "canonical": "ae"
+  },
+  {
+    "tokens": ["ö", "oe"],
+    "skipBoundaries": true,
+    "full": "ö",
+    "skipDiacriticStripping": true,
+    "canonical": "oe"
+  },
+  {
+    "tokens": ["ü", "ue"],
+    "skipBoundaries": true,
+    "full": "ü",
+    "skipDiacriticStripping": true,
+    "canonical": "ue"
+  },
+  {
+    "tokens": ["$1 str", "([^ ]+)(strasse|str|straße)"],
+    "full": "([^ ]+)(strasse|str|straße)",
+    "canonical": "$1 str",
+    "regex": true,
+    "skipDiacriticStripping": true,
+    "spanBoundaries": 0
+  }
+]

--- a/test/fixtures/de-simple.json
+++ b/test/fixtures/de-simple.json
@@ -1,1 +1,50 @@
-[["a.d.","auf der"],["a","am","an","a d","a.d","auf","an der"],["i","im","in","i d","i.d","i.d.","in der"],["Bf","Bhf","Bahnhof","Bahnhofstr","Bahnhofstraße"],["bg","berg","burg","bergstr","bergstraße"],["Br","Brücke"],["Ch","Chaussee"],["D","Damm"],["d","der"],["df","dorf","dorfstr","dorfstraße"],["Dr","Doktor"],["G","Gasse"],["Gr","Große","Großer","Großes"],["Hbf","Hauptstr","Hauptstraße","Hauptbahnhof"],["Hl","Heiligen"],["Kl","Kleine","Kleiner","Kleines"],["Kr","Krs","Kreis"],["Lk","Lkr","Lkrs","Landkrs","Landkreis"],["o","ob"],["Ob","Obere","Oberer","Oberes"],["Pl","Platz"],["Rh","Rhein"],["Ring","Ringstr","Ringstraße"],["St","Sankt"],["Str","Straße","Strasse"],["U","Untere","Unterer","Unteres"],["v","von"],["Wg","Weg"],["z","zum"],["ä",{"skipBoundaries":true,"skipDiacriticStripping":true,"text":"ae"}],["ö",{"skipBoundaries":true,"skipDiacriticStripping":true,"text":"oe"}],["ü",{"skipBoundaries":true,"skipDiacriticStripping":true,"text":"ue"}],["$1 str",{"skipDiacriticStripping":true,"regex":true,"text":"([^ ]+)(strasse|str|straße)"}]]
+[
+  ["a.d.", "auf der"],
+  ["a", "am", "an", "a d", "a.d", "auf", "an der"],
+  ["i", "im", "in", "i d", "i.d", "i.d.", "in der"],
+  ["Bf", "Bhf", "Bahnhof"],
+  ["bg", "berg", "burg"],
+  ["Br", "Brücke"],
+  ["Ch", "Chaussee"],
+  ["D", "Damm"],
+  ["d", "der"],
+  ["df", "dorf"],
+  ["Dr", "Doktor"],
+  ["G", "Gasse"],
+  ["Gr", "Große", "Großer", "Großes"],
+  ["Hbf", "Hauptbahnhof"],
+  ["Hl", "Heiligen"],
+  ["Kl", "Kleine", "Kleiner", "Kleines"],
+  ["Kr", "Krs", "Kreis"],
+  ["Lk", "Lkr", "Lkrs", "Landkrs", "Landkreis"],
+  ["o", "ob"],
+  ["Ob", "Obere", "Oberer", "Oberes"],
+  ["Pl", "Platz"],
+  ["Rh", "Rhein"],
+  ["St", "Sankt"],
+  ["Str", "Straße", "Strasse"],
+  ["U", "Untere", "Unterer", "Unteres"],
+  ["v", "von"],
+  ["Wg", "Weg"],
+  ["z", "zum"],
+  [
+    "ä",
+    { "skipBoundaries": true, "skipDiacriticStripping": true, "text": "ae" }
+  ],
+  [
+    "ö",
+    { "skipBoundaries": true, "skipDiacriticStripping": true, "text": "oe" }
+  ],
+  [
+    "ü",
+    { "skipBoundaries": true, "skipDiacriticStripping": true, "text": "ue" }
+  ],
+  [
+    "$1 str",
+    {
+      "skipDiacriticStripping": true,
+      "regex": true,
+      "text": "([^ ]+)(strasse|str|straße)"
+    }
+  ]
+]

--- a/tokens/de.json
+++ b/tokens/de.json
@@ -76,9 +76,7 @@
         "tokens": [
             "Bf",
             "Bhf",
-            "Bahnhof",
-            "Bahnhofstr",
-            "Bahnhofstraße"
+            "Bahnhof"
         ],
         "full": "Bahnhof",
         "canonical": "Bf"
@@ -86,9 +84,7 @@
     {
         "tokens": [
             "bg",
-            "berg",
-            "bergstr",
-            "bergstraße"
+            "berg"
         ],
         "full": "berg",
         "canonical": "bg"
@@ -141,9 +137,7 @@
     {
         "tokens": [
             "df",
-            "dorf",
-            "dorfstr",
-            "dorfstraße"
+            "dorf"
         ],
         "full": "dorf",
         "canonical": "df"
@@ -194,8 +188,6 @@
     {
         "tokens": [
             "Hbf",
-            "Hauptstr",
-            "Hauptstraße",
             "Hauptbahnhof"
         ],
         "full": "Hauptbahnhof",
@@ -304,15 +296,6 @@
         ],
         "full": "Rhein",
         "canonical": "Rh"
-    },
-    {
-        "tokens": [
-            "Ring",
-            "Ringstr",
-            "Ringstraße"
-        ],
-        "full": "Ringstr",
-        "canonical": "Ring"
     },
     {
         "tokens": [

--- a/tokens/de.json
+++ b/tokens/de.json
@@ -417,17 +417,6 @@
     },
     {
         "tokens": [
-            "(strasse|str).?$"
-        ],
-        "full": "(strasse|str).?$",
-        "canonical": "straße",
-        "regex": true,
-        "skipDiacriticStripping": true,
-        "spanBoundaries": 0,
-        "onlyUseWhile": ["processing"]
-    },
-    {
-        "tokens": [
             "$1 str",
             "([^ ]+)(strasse|str|straße)"
         ],
@@ -435,7 +424,6 @@
         "canonical": "$1 str",
         "regex": true,
         "skipDiacriticStripping": true,
-        "spanBoundaries": 0,
-        "onlyUseWhile": ["indexing", "querying"]
+        "spanBoundaries": 0    
     }
 ]


### PR DESCRIPTION
This PR removes unneeded German tokens. We were able to implement the regex of the current " str" replacement. Using the current str replacement of splitting "strasse", "straße" or "str" off into its own word also removed the need to add tokens such as "banhofstrasse".