### PR TITLE
Fix TokenFileImportNotSupported in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ authors = [
 edition = "2018"
 
 [dependencies]
-rust-embed="5.5.1"
 alphanumeric-sort = "1.0.6"
 fancy-regex = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dependencies.rust-embed]
+version = "5.5.1"
+default-features = false
+features = ["debug-embed"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Tokens {
     }
 
     pub fn import(lc: &str) -> Result<String, Error> {
-        match Tokens::get(format!("./{}.json", &lc).as_str()) {
+        match Tokens::get(format!("{}.json", &lc).as_str()) {
             Some(tokens) => match std::str::from_utf8(tokens.as_ref()) {
                 Ok(tokens) => Ok(String::from(tokens)),
                 _ => Err(Error::TokenFileImportNotSupported(lc.to_string()))


### PR DESCRIPTION
rust-embed falls back to reading from the file system in debug builds,
which allowed a bad path to be used to access embedded token files in
our tests. This fixes the path used to access the embedded token files
and enables the debug-embed feature to force rust-embed to always embed
the token files.

/cc @mapbox/search 