### PR TITLE
Enable clippy lint checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: "Install Rust"
           command: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.34.0"
+      - run:
+          name: "Install Clippy"
+          command: "~/.cargo/bin/rustup component add clippy"
 
       - checkout
 
@@ -32,3 +35,6 @@ jobs:
       - run:
           name: "cargo test"
           command: "~/.cargo/bin/cargo test"
+      - run:
+          name: "cargo clippy"
+          command: "~/.cargo/bin/cargo clippy --all-targets --all-features -- -D warnings"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::collections::HashMap;
 use fancy_regex::Regex;
 
@@ -221,13 +220,10 @@ mod tests {
 
         for lc in map.values() {
             for tk in lc {
-                assert!(tk.tokens.len() > 0);
-                match &tk.only_layers {
-                    Some(l) => {
-                        assert_eq!(l[0], "address");
-                        assert_eq!(l.len(), 1);
-                    },
-                    _ => (),
+                assert!(!tk.tokens.is_empty());
+                if let Some(l) = &tk.only_layers {
+                    assert_eq!(l[0], "address");
+                    assert_eq!(l.len(), 1);
                 }
             }
         }
@@ -237,7 +233,7 @@ mod tests {
         let mut lcs = Vec::new();
         for entry in fs::read_dir("./tokens").unwrap() {
             let file_name = entry.unwrap().file_name().into_string().unwrap();
-            let file_components: Vec<&str> = file_name.split(".").collect();
+            let file_components: Vec<&str> = file_name.split('.').collect();
             if file_components[1] == "json" {
                 lcs.push(file_components[0].to_owned());
             }


### PR DESCRIPTION
This cleans up the existing clippy lint warnings and configures the CI build to fail if any warnings are introduced.

/cc @mapbox/search 