### PR TITLE
Restrict 'sev' token replacement to addresses only

### DIFF
--- a/tokens/cs.json
+++ b/tokens/cs.json
@@ -17,8 +17,9 @@
     "tokens": ["sever", "s"],
     "full": "sever",
     "canonical": "s",
-    "note": "translates to 'north'",
-    "type": "cardinal"
+    "note": "translates to 'north'; applying this only to addresses because in mixed-language layers it ends up doing weird conflations with 'south', which is 's' elsewhere",
+    "type": "cardinal",
+    "onlyLayers": ["address"]
   },
   {
     "tokens": ["východ", "vychod", "v"],


### PR DESCRIPTION
The `"sev" => "s"` token replacement in Czech does weird things when combined with tokens from other languages in multi-language indexes, and doesn't seem obviously relevant other than to addresses, so this PR restricts it to only being used in addresses.