### PR TITLE
Elision support

### DIFF
--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -806,10 +806,10 @@
     {
         "tokens": [
           "$1$2",
-          "(l|d) ([a|e|i|o|u]\\w+)"
+          "(l|d) ([a|e|i|o|u].+)"
         ],
         "onlyLayers": ["address"],
-        "full": "(l|d) ([a|e|i|o|u]\\w+)",
+        "full": "(l|d) ([a|e|i|o|u].+)",
         "canonical": "$1$2",
         "regex": true,
         "spanBoundaries": 1

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -809,6 +809,7 @@
           "(l|d) ([a|e|i|o|u].+)"
         ],
         "onlyLayers": ["address"],
+        "onlyCountries": ["fr"],
         "full": "(l|d) ([a|e|i|o|u].+)",
         "canonical": "$1$2",
         "regex": true,

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -810,7 +810,7 @@
         ],
         "onlyLayers": ["address"],
         "onlyCountries": ["fr"],
-        "full": "(l|d) ([a|e|i|o|u].+)",
+        "full": "(l|d) ([a|e|i|o|u|h|y].+)",
         "canonical": "$1$2",
         "regex": true,
         "spanBoundaries": 1

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -806,11 +806,11 @@
     {
         "tokens": [
           "$1$2",
-          "(l|d) ([a|e|i|o|u|h|y].+)"
+          "(l|d) ([aeiouhy][^ ]+)"
         ],
         "onlyLayers": ["address"],
         "onlyCountries": ["fr"],
-        "full": "(l|d) ([a|e|i|o|u|h|y].+)",
+        "full": "(l|d) ([aeiouhy][^ ]+)",
         "canonical": "$1$2",
         "regex": true,
         "spanBoundaries": 1

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -806,7 +806,7 @@
     {
         "tokens": [
           "$1$2",
-          "(l|d) ([a|e|i|o|u].+)"
+          "(l|d) ([a|e|i|o|u|h|y].+)"
         ],
         "onlyLayers": ["address"],
         "onlyCountries": ["fr"],

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -802,5 +802,16 @@
         "full": "Les",
         "canonical": "Les",
         "type": "determiner"
+    },
+    {
+        "tokens": [
+          "$1$2",
+          "(l|d) ([a|e|i|o|u]\\w+)"
+        ],
+        "onlyLayers": ["address"],
+        "full": "(l|d) ([a|e|i|o|u]\\w+)",
+        "canonical": "$1$2",
+        "regex": true,
+        "spanBoundaries": 1
     }
 ]


### PR DESCRIPTION
## Context

This PR adds a complex token replacement for cases where in France, we've seen users replace apostrophe's with a space for  articles/prepositions. Currently, we're only planning to apply this token replacement to addresses in France - given that we're most likely to see this behaviour there.


## Next Steps
- [x] Build a new index with this version of geocoder-abbreviations 
- [x] Test behaviour with new token replacement 