### PR TITLE
French number token updates

### DIFF
--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -162,7 +162,8 @@
         "full": "dix sept",
         "canonical": "17",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -172,7 +173,8 @@
         "full": "dix huit",
         "canonical": "18",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -182,7 +184,8 @@
         "full": "dix neuf",
         "canonical": "19",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -666,15 +669,6 @@
     },
     {
         "tokens": [
-            "giratoire"
-        ],
-        "full": "general",
-        "canonical": "gen",
-        "type": "way",
-        "note": "translates to 'roundabout'"
-    },
-    {
-        "tokens": [
             "Hop",
             "Hôpital"
         ],
@@ -728,7 +722,8 @@
     {
         "tokens": [
             "ld",
-            "ldit"
+            "ldit",
+            "lieudit"
         ],
         "full": "ldit",
         "canonical": "ld",
@@ -744,7 +739,8 @@
         "full": "Lieu-dit",
         "canonical": "Ld",
         "spanBoundaries": 1,
-        "note": "geographical place so small it's what people call it locally without having any political/administrative identity. A few houses grouped together out in the countryside but nothing more"
+        "note": "geographical place so small it's what people call it locally without having any political/administrative identity. A few houses grouped together out in the countryside but nothing more",
+        "regex": true
     },
     {
         "tokens": [
@@ -756,22 +752,14 @@
     },
     {
         "tokens": [
-            "lgén",
-            "lgen"
-        ],
-        "full": "leiutenant",
-        "canonical": "lgen"
-    },
-    {
-        "tokens": [
-            "lieutenant général",
-            "l gén",
+            "lgen",
             "l gen",
             "leiutenant general"
         ],
         "full": "leiutenant general",
-        "canonical": "l gen",
-        "spanBoundaries": 1
+        "canonical": "lgen",
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -792,9 +780,9 @@
     {
         "tokens": [
             "Mal",
-            "Maréchal"
+            "Marechal"
         ],
-        "full": "Maréchal",
+        "full": "Marechal",
         "canonical": "Mal"
     },
     {
@@ -831,22 +819,17 @@
     },
     {
         "tokens": [
-            "mgén",
-            "mgen"
-        ],
-        "full": "major general",
-        "canonical": "mgen"
-    },
-    {
-        "tokens": [
-            "major général",
-            "m gén",
+            "mgen",
             "m gen",
+            "maj gen",
+            "maj general",
+            "major gen",
             "major general"
         ],
         "full": "major general",
-        "canonical": "m gen",
-        "spanBoundaries": 1
+        "canonical": "mgen",
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -912,7 +895,8 @@
       "canonical": "passage commun",
       "type": "way",
       "spanBoundaries": 1,
-      "note": "translates to 'common border crossings or common paths'"
+      "note": "translates to 'common border crossings or common paths'",
+      "regex": true
     },
     {
         "tokens": [
@@ -1010,7 +994,8 @@
         "onlyLayers": ["address"],
         "note": "translates to 'roundabout'",
         "type": "way",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "regex": true
     },
     {
         "tokens": [
@@ -1264,7 +1249,8 @@
         ],
         "full": "zone industrielle",
         "canonical": "zi",
-        "type": "way"
+        "type": "way",
+        "regex": true
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -757,7 +757,7 @@
             "leiutenant general"
         ],
         "full": "leiutenant general",
-        "canonical": "lgen",
+        "canonical": "l gen",
         "spanBoundaries": 1
     },
     {
@@ -828,7 +828,7 @@
             "major general"
         ],
         "full": "major general",
-        "canonical": "mgen",
+        "canonical": "m gen",
         "spanBoundaries": 1
     },
     {

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -162,8 +162,7 @@
         "full": "dix sept",
         "canonical": "17",
         "type": "number",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -173,8 +172,7 @@
         "full": "dix huit",
         "canonical": "18",
         "type": "number",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -184,8 +182,7 @@
         "full": "dix neuf",
         "canonical": "19",
         "type": "number",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -660,7 +657,9 @@
     },
     {
         "tokens": [
+            "général",
             "general",
+            "gén",
             "gen",
             "gal"
         ],
@@ -739,8 +738,7 @@
         "full": "Lieu-dit",
         "canonical": "Ld",
         "spanBoundaries": 1,
-        "note": "geographical place so small it's what people call it locally without having any political/administrative identity. A few houses grouped together out in the countryside but nothing more",
-        "regex": true
+        "note": "geographical place so small it's what people call it locally without having any political/administrative identity. A few houses grouped together out in the countryside but nothing more"
     },
     {
         "tokens": [
@@ -752,14 +750,15 @@
     },
     {
         "tokens": [
+            "lgén",
             "lgen",
+            "l gén",
             "l gen",
             "leiutenant general"
         ],
         "full": "leiutenant general",
         "canonical": "lgen",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -780,9 +779,9 @@
     {
         "tokens": [
             "Mal",
-            "Marechal"
+            "Maréchal"
         ],
-        "full": "Marechal",
+        "full": "Maréchal",
         "canonical": "Mal"
     },
     {
@@ -819,17 +818,18 @@
     },
     {
         "tokens": [
+            "mgén",
             "mgen",
             "m gen",
             "maj gen",
             "maj general",
             "major gen",
+            "major général",
             "major general"
         ],
         "full": "major general",
         "canonical": "mgen",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -895,8 +895,7 @@
       "canonical": "passage commun",
       "type": "way",
       "spanBoundaries": 1,
-      "note": "translates to 'common border crossings or common paths'",
-      "regex": true
+      "note": "translates to 'common border crossings or common paths'"
     },
     {
         "tokens": [
@@ -989,13 +988,12 @@
             "rond point",
             "rond-point"
         ],
-        "full": "rond-point",
-        "canonical": "rpt",
+        "full": "Rond-Point",
+        "canonical": "Rpt",
         "onlyLayers": ["address"],
         "note": "translates to 'roundabout'",
         "type": "way",
-        "spanBoundaries": 1,
-        "regex": true
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -1249,8 +1247,7 @@
         ],
         "full": "zone industrielle",
         "canonical": "zi",
-        "type": "way",
-        "regex": true
+        "type": "way"
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -888,16 +888,6 @@
         "type": "way"
     },
     {
-      "tokens": [
-          "passage commun"
-        ],
-      "full": "passage commun",
-      "canonical": "passage commun",
-      "type": "way",
-      "spanBoundaries": 1,
-      "note": "translates to 'common border crossings or common paths'"
-    },
-    {
         "tokens": [
             "Pl",
             "Place",

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -750,7 +750,14 @@
     },
     {
         "tokens": [
-            "lgen",
+            "lgén",
+            "lgen"
+        ],
+        "full": "leiutenant general",
+        "canonical": "lgen"
+    },
+    {
+        "tokens": [
             "l gén",
             "l gen",
             "lieutenant général",
@@ -818,7 +825,14 @@
     },
     {
         "tokens": [
-            "mgen",
+            "mgén",
+            "mgen"
+        ],
+        "full": "major general",
+        "canonical": "mgen"
+    },
+    {
+        "tokens": [
             "m gén",
             "m gen",
             "maj gen",

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -155,6 +155,33 @@
     },
     {
         "tokens": [
+            "17",
+            "dix sept"
+        ],
+        "full": "seventeen",
+        "canonical": "17",
+        "type": "number"
+    },
+    {
+        "tokens": [
+            "18",
+            "dix huit"
+        ],
+        "full": "eighteen",
+        "canonical": "18",
+        "type": "number"
+    },
+    {
+        "tokens": [
+            "19",
+            "dix neuf"
+        ],
+        "full": "nineteen",
+        "canonical": "19",
+        "type": "number"
+    },
+    {
+        "tokens": [
             "20",
             "vingt"
         ],

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -40,6 +40,7 @@
         "tokens": [
             "4",
             "quatre"
+            "quatres"
         ],
         "full": "quatre",
         "canonical": "4",
@@ -470,7 +471,8 @@
     {
         "tokens": [
             "Av",
-            "Avenue"
+            "Avenue",
+            "Avenues"
         ],
         "full": "Avenue",
         "canonical": "Av",
@@ -520,7 +522,8 @@
         "tokens": [
             "Ch",
             "Che",
-            "Chemin"
+            "Chemin",
+            "Chemins"
         ],
         "full": "Chemin",
         "canonical": "Ch",
@@ -597,7 +600,8 @@
     {
         "tokens": [
             "Dr",
-            "Docteur"
+            "Docteur",
+            "Docteurs"
         ],
         "full": "Docteur",
         "canonical": "Dr"
@@ -664,6 +668,15 @@
     },
     {
         "tokens": [
+            "giratoire"
+        ],
+        "full": "general",
+        "canonical": "gen",
+        "type": "way",
+        "notes": "translates to 'roundabout'"
+    },
+    {
+        "tokens": [
             "Hop",
             "Hôpital"
         ],
@@ -697,7 +710,8 @@
     {
         "tokens": [
             "Imp",
-            "Impasse"
+            "Impasse",
+            "Impasses"
         ],
         "full": "Impasse",
         "canonical": "Imp",
@@ -736,10 +750,18 @@
     },
     {
         "tokens": [
+            "lt",
+            "lieutenant"
+        ],
+        "full": "lieutenant",
+        "canonical": "lt"
+    },
+    {
+        "tokens": [
             "lgén",
             "lgen"
         ],
-        "full": "leiutenant general",
+        "full": "leiutenant",
         "canonical": "lgen"
     },
     {
@@ -980,11 +1002,13 @@
     },
     {
         "tokens": [
-            "Rpt",
-            "Rond-Point"
+            "rpt",
+            "rd pt",
+            "rond point",
+            "rond-point"
         ],
-        "full": "Rond-Point",
-        "canonical": "Rpt",
+        "full": "rond-point",
+        "canonical": "rpt",
         "onlyLayers": ["address"],
         "note": "translates to 'roundabout'",
         "type": "way",
@@ -992,8 +1016,21 @@
     },
     {
         "tokens": [
+            "rpt",
+            "rdpt",
+            "rondpoint"
+        ],
+        "full": "rondpoint",
+        "canonical": "rpt",
+        "onlyLayers": ["address"],
+        "note": "translates to 'roundabout'",
+        "type": "way"
+    },
+    {
+        "tokens": [
             "Rte",
-            "Route"
+            "Route",
+            "Routes"
         ],
         "full": "Route",
         "canonical": "Rte",
@@ -1153,6 +1190,17 @@
     },
     {
         "tokens": [
+            "rampe",
+            "rpe",
+            "rmpe",
+            "rmp"
+        ],
+        "full": "rampe",
+        "canonical": "rmp",
+        "type": "way"
+    },
+    {
+        "tokens": [
             "Za",
             "Zone d'activité"
         ],
@@ -1227,6 +1275,15 @@
         ],
         "full": "voie",
         "canonical": "voi",
+        "type": "way"
+    },
+    {
+        "tokens": [
+            "passe",
+            "pass"
+        ],
+        "full": "passe",
+        "canonical": "pass",
         "type": "way"
     },
     {

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -754,6 +754,7 @@
             "lgen",
             "l gén",
             "l gen",
+            "lieutenant général",
             "leiutenant general"
         ],
         "full": "leiutenant general",
@@ -820,6 +821,7 @@
         "tokens": [
             "mgén",
             "mgen",
+            "m gén",
             "m gen",
             "maj gen",
             "maj general",

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -39,7 +39,7 @@
     {
         "tokens": [
             "4",
-            "quatre"
+            "quatre",
             "quatres"
         ],
         "full": "quatre",
@@ -657,9 +657,7 @@
     },
     {
         "tokens": [
-            "général",
             "general",
-            "gén",
             "gen",
             "gal"
         ],
@@ -673,7 +671,7 @@
         "full": "general",
         "canonical": "gen",
         "type": "way",
-        "notes": "translates to 'roundabout'"
+        "note": "translates to 'roundabout'"
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -750,7 +750,6 @@
     },
     {
         "tokens": [
-            "lgén",
             "lgen",
             "l gén",
             "l gen",
@@ -819,7 +818,6 @@
     },
     {
         "tokens": [
-            "mgén",
             "mgen",
             "m gén",
             "m gen",
@@ -990,8 +988,8 @@
             "rond point",
             "rond-point"
         ],
-        "full": "Rond-Point",
-        "canonical": "Rpt",
+        "full": "rond point",
+        "canonical": "rpt",
         "onlyLayers": ["address"],
         "note": "translates to 'roundabout'",
         "type": "way",
@@ -1249,7 +1247,8 @@
         ],
         "full": "zone industrielle",
         "canonical": "zi",
-        "type": "way"
+        "type": "way",
+        "spanBoundaries": 1
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -1106,6 +1106,15 @@
     },
     {
         "tokens": [
+            "ven",
+            "venelle"
+        ],
+        "full": "venelle",
+        "canonical": "ven",
+        "type": "way"
+    },
+    {
+        "tokens": [
             "BP",
             "Boîte Postale"
         ],
@@ -1201,6 +1210,15 @@
         "full": "Les",
         "canonical": "Les",
         "type": "determiner"
+    },
+    {
+        "tokens": [
+            "zone industrielle",
+            "zi"
+        ],
+        "full": "zone industrielle",
+        "canonical": "zi",
+        "type": "way"
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -14,7 +14,7 @@
             "un",
             "une"
         ],
-        "full": "one",
+        "full": "une",
         "canonical": "1",
         "type": "number"
     },
@@ -23,7 +23,7 @@
             "2",
             "deux"
         ],
-        "full": "two",
+        "full": "deux",
         "canonical": "2",
         "type": "number"
     },
@@ -32,7 +32,7 @@
             "3",
             "trois"
         ],
-        "full": "three",
+        "full": "trois",
         "canonical": "3",
         "type": "number"
     },
@@ -41,7 +41,7 @@
             "4",
             "quatre"
         ],
-        "full": "four",
+        "full": "quatre",
         "canonical": "4",
         "type": "number"
     },
@@ -50,7 +50,7 @@
             "5",
             "cinq"
         ],
-        "full": "five",
+        "full": "cinq",
         "canonical": "5",
         "type": "number"
     },
@@ -68,7 +68,7 @@
             "7",
             "sept"
         ],
-        "full": "seven",
+        "full": "sept",
         "canonical": "7",
         "type": "number"
     },
@@ -77,7 +77,7 @@
             "8",
             "huit"
         ],
-        "full": "eight",
+        "full": "huit",
         "canonical": "8",
         "type": "number"
     },
@@ -86,7 +86,7 @@
             "9",
             "neuf"
         ],
-        "full": "nine",
+        "full": "neuf",
         "canonical": "9",
         "type": "number"
     },
@@ -95,7 +95,7 @@
             "10",
             "dix"
         ],
-        "full": "ten",
+        "full": "dix",
         "canonical": "10",
         "type": "number"
     },
@@ -104,7 +104,7 @@
             "11",
             "onze"
         ],
-        "full": "eleven",
+        "full": "onze",
         "canonical": "11",
         "type": "number"
     },
@@ -113,7 +113,7 @@
             "12",
             "douze"
         ],
-        "full": "twelve",
+        "full": "douze",
         "canonical": "12",
         "type": "number"
     },
@@ -122,7 +122,7 @@
             "13",
             "treize"
         ],
-        "full": "thirteen",
+        "full": "treize",
         "canonical": "13",
         "type": "number"
     },
@@ -131,7 +131,7 @@
             "14",
             "quatorze"
         ],
-        "full": "fourteen",
+        "full": "quatorze",
         "canonical": "14",
         "type": "number"
     },
@@ -140,7 +140,7 @@
             "15",
             "quinze"
         ],
-        "full": "fifteen",
+        "full": "quinze",
         "canonical": "15",
         "type": "number"
     },
@@ -149,7 +149,7 @@
             "16",
             "seize"
         ],
-        "full": "sixteen",
+        "full": "seize",
         "canonical": "16",
         "type": "number"
     },
@@ -158,27 +158,30 @@
             "17",
             "dix sept"
         ],
-        "full": "seventeen",
+        "full": "dix sept",
         "canonical": "17",
-        "type": "number"
+        "type": "number",
+        "spanBoundaries": 1
     },
     {
         "tokens": [
             "18",
             "dix huit"
         ],
-        "full": "eighteen",
+        "full": "dix huit",
         "canonical": "18",
-        "type": "number"
+        "type": "number",
+        "spanBoundaries": 1
     },
     {
         "tokens": [
             "19",
             "dix neuf"
         ],
-        "full": "nineteen",
+        "full": "dix neuf",
         "canonical": "19",
-        "type": "number"
+        "type": "number",
+        "spanBoundaries": 1
     },
     {
         "tokens": [
@@ -880,6 +883,16 @@
         "full": "Passage",
         "canonical": "Pas",
         "type": "way"
+    },
+    {
+      "tokens": [
+          "passage commun"
+        ],
+      "full": "passage commun",
+      "canonical": "passage commun",
+      "type": "way",
+      "spanBoundaries": 1,
+      "note": "translates to 'common border crossings or common paths'"
     },
     {
         "tokens": [


### PR DESCRIPTION
- Use French words for numbers and a few instances of plurals being used in rural areas of France.
- Properly set `spanBoundaries` parameter for multi-word tokens to be properly evaluated and matchied during linking.