### PR TITLE
Add Poland Token

### DIFF
--- a/tokens/pl.json
+++ b/tokens/pl.json
@@ -55,6 +55,6 @@
         ],
         "full": "Majora",
         "canonical": "Mjr.",
-        "note": "translates to 'raise'"
+        "note": "translates to 'major'"
     }
 ]

--- a/tokens/pl.json
+++ b/tokens/pl.json
@@ -32,18 +32,12 @@
     {
         "tokens": [
             "Św.",
-            "Świętego"
-        ],
-        "full": "Świętego",
-        "canonical": "Św."
-    },
-    {
-        "tokens": [
-            "Św",
+            "Świętego",
             "Świętej"
         ],
-        "full": "Świętej",
-        "canonical": "Św"
+        "full": "Świętego",
+        "canonical": "Św.",
+        "note": "translates to 'Saint'",
     },
     {
         "tokens": [
@@ -51,7 +45,8 @@
             "Generała"
         ],
         "full": "Generała",
-        "canonical": "Gen."
+        "canonical": "Gen.",
+        "note": "translates to 'general'",
     },
     {
         "tokens": [
@@ -59,6 +54,7 @@
             "Majora"
         ],
         "full": "Majora",
-        "canonical": "Mjr."
+        "canonical": "Mjr.",
+        "note": "translates to 'raise'",
     }
 ]

--- a/tokens/pl.json
+++ b/tokens/pl.json
@@ -37,7 +37,7 @@
         ],
         "full": "Świętego",
         "canonical": "Św.",
-        "note": "translates to 'Saint'",
+        "note": "translates to 'Saint'"
     },
     {
         "tokens": [
@@ -46,7 +46,7 @@
         ],
         "full": "Generała",
         "canonical": "Gen.",
-        "note": "translates to 'general'",
+        "note": "translates to 'general'"
     },
     {
         "tokens": [
@@ -55,6 +55,6 @@
         ],
         "full": "Majora",
         "canonical": "Mjr.",
-        "note": "translates to 'raise'",
+        "note": "translates to 'raise'"
     }
 ]

--- a/tokens/pl.json
+++ b/tokens/pl.json
@@ -31,30 +31,30 @@
     },
     {
         "tokens": [
-            "Św.",
+            "Św",
             "Świętego",
             "Świętej"
         ],
         "full": "Świętego",
-        "canonical": "Św.",
+        "canonical": "Św",
         "note": "translates to 'Saint'"
     },
     {
         "tokens": [
-            "Gen.",
+            "Gen",
             "Generała"
         ],
         "full": "Generała",
-        "canonical": "Gen.",
+        "canonical": "Gen",
         "note": "translates to 'general'"
     },
     {
         "tokens": [
-            "Mjr.",
+            "Mjr",
             "Majora"
         ],
         "full": "Majora",
-        "canonical": "Mjr.",
+        "canonical": "Mjr",
         "note": "translates to 'major'"
     }
 ]

--- a/tokens/pl.json
+++ b/tokens/pl.json
@@ -28,5 +28,37 @@
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way"
+    },
+    {
+        "tokens": [
+            "Św.",
+            "Świętego"
+        ],
+        "full": "Świętego",
+        "canonical": "Św."
+    },
+    {
+        "tokens": [
+            "Św",
+            "Świętej"
+        ],
+        "full": "Świętej",
+        "canonical": "Św"
+    },
+    {
+        "tokens": [
+            "Gen.",
+            "Generała"
+        ],
+        "full": "Generała",
+        "canonical": "Gen."
+    },
+    {
+        "tokens": [
+            "Mjr.",
+            "Majora"
+        ],
+        "full": "Majora",
+        "canonical": "Mjr."
     }
 ]


### PR DESCRIPTION
### Goal

Obeserve some additional tokens can be added in to improve the matching between address street name and road network name in Poland. This helps solve ~700 address orphan clusters in Poland.

@ilissablech 