### PR TITLE
bump version to 4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## 4.6.1
+
+- :rocket: Token additions for Slovak(SK), Slovania(SI), Serbia(RS), Lithuania(LT), Hungary(HU).
+
 ## 4.6.0
 
 - :rocket: Token additions for Portuguese.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bump version to 4.6.1 to add tokens for OSM new countriess: Slovak(SK), Slovania(SI), Serbia(RS), Lithuania(LT), Hungary(HU).