### PR TITLE
Update hungary and romania tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## 4.6.2
+
+- :rocket: Token additions for Hungary(HU) and Romania(RO).
+
 ## 4.6.1
 
 - :rocket: Token additions for Slovak(SK), Slovania(SI), Serbia(RS), Lithuania(LT), Hungary(HU).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/hu.json
+++ b/tokens/hu.json
@@ -28,5 +28,16 @@
         "canonical": "rpt",
         "note": "translates to 'quay'",
         "type": "way"
+    },
+    {
+        "tokens": [
+            "utca",
+            "ut",
+            "u"
+        ],
+        "full": "utca",
+        "canonical": "u",
+        "note": "translates to 'street'",
+        "type": "way"
     }
 ]

--- a/tokens/ro.json
+++ b/tokens/ro.json
@@ -20,7 +20,14 @@
     },
     {
         "tokens": [
+            "bd",
+            "bul",
+            "blv",
+            "bdul",
             "blvd",
+            "bulev",
+            "bulevard",
+            "bulevardu",
             "bulevardul"
         ],
         "full": "bulevardul",
@@ -39,5 +46,17 @@
         "note": "translates to 'highway'",
         "onlyLayers": ["address"],
         "type": "way"
+    },
+    {
+        "tokens": [
+            "$1",
+            "(?:NR|NR.)\s?\d+"
+        ],
+        "canonical": "$1",
+        "full": "(?:NR|NR.)\s?\d+",
+        "regex": true,
+        "spanBoundaries": 1,
+        "onlyLayers": ["address"],
+        "type": "unit"
     }
 ]

--- a/tokens/ro.json
+++ b/tokens/ro.json
@@ -50,10 +50,10 @@
     {
         "tokens": [
             "$1",
-            "(?:NR|NR.)\s?\d+"
+            "(?:NR|NR.)\\s?\\d+"
         ],
         "canonical": "$1",
-        "full": "(?:NR|NR.)\s?\d+",
+        "full": "(?:NR|NR.)\\s?\\d+",
         "regex": true,
         "spanBoundaries": 1,
         "onlyLayers": ["address"],


### PR DESCRIPTION
This PR is to update tokens in Hungary and Romania to improve the search accuracy. Bump the version to 4.6.2.