### PR TITLE
Elison support for Canada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## 4.6.4
+
+- :rocket: Add elison support for Canada.
+
 ## 4.6.3
 
 - :bug: Fix a regex bug in Romania(RO).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2988,8 +2988,18 @@
         "full": "([0-9]+)(?:st|nd|rd|th)",
         "regex": true,
         "onlyLayers": ["address"],
-        "onlyCountries": ["us", "ca"],
+        "onlyCountries": ["us"],
         "reduceRelevance": true
-
+    },
+    {
+        "tokens": [
+            "$1",
+            "([0-9]+)(?:st|nd|rd|th)"
+        ],
+        "canonical": "$1",
+        "full": "([0-9]+)(?:st|nd|rd|th)",
+        "regex": true,
+        "onlyLayers": ["address"],
+        "onlyCountries": ["ca"]
     }
 ]

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2990,16 +2990,5 @@
         "onlyLayers": ["address"],
         "onlyCountries": ["us"],
         "reduceRelevance": true
-    },
-    {
-        "tokens": [
-            "$1",
-            "([0-9]+)(?:st|nd|rd|th)"
-        ],
-        "canonical": "$1",
-        "full": "([0-9]+)(?:st|nd|rd|th)",
-        "regex": true,
-        "onlyLayers": ["address"],
-        "onlyCountries": ["ca"]
     }
 ]

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -2988,7 +2988,7 @@
         "full": "([0-9]+)(?:st|nd|rd|th)",
         "regex": true,
         "onlyLayers": ["address"],
-        "onlyCountries": ["us"],
+        "onlyCountries": ["us", "ca"],
         "reduceRelevance": true
 
     }

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -1314,7 +1314,7 @@
             "(l|d) ([aeiouhy][^ ]+)"
         ],
         "onlyLayers": ["address"],
-        "onlyCountries": ["fr"],
+        "onlyCountries": ["fr", "ca"],
         "full": "(l|d) ([aeiouhy][^ ]+)",
         "canonical": "$1$2",
         "regex": true,


### PR DESCRIPTION
We added in elison support for France to support when people search by replacing apostrophes with a space for articles/prepositions. It's likely that similar search methods would be used in the French speaking parts of Canada.

cc: @mapbox/search-addresses 