### PR TITLE
Add latvian token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## 4.6.5
+
+- :rocket: Token additions for Latvia(LV).
+
 ## 4.6.4
 
 - :rocket: Add elison support for Canada.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -27,23 +27,5 @@
         "full": "numurs",
         "canonical": "no",
         "note": "translates to 'nummber'"
-    },
-    {
-        "tokens": [
-            "iela"
-        ],
-        "full": "iela",
-        "canonical": "iela",
-        "note": "translates to 'street'",
-        "type": "way"
-    },
-    {
-        "tokens": [
-            "prospekts"
-        ],
-        "full": "prospekts",
-        "canonical": "prospekts",
-        "note": "translates to 'avenue'",
-        "type": "way"
     }
 ]

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -1,0 +1,21 @@
+[
+    {
+        "tokens": [
+            "dzīvoklis",
+            "dz"
+        ],
+        "full": "dzīvoklis",
+        "canonical": "dz",
+        "note": "translates to 'apartment'"
+    },
+    {
+        "tokens": [
+            "gatve",
+            "g"
+        ],
+        "full": "gatve",
+        "canonical": "g",
+        "note": "translates to 'alley'",
+        "type": "way"
+    }
+]

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -17,5 +17,33 @@
         "canonical": "g",
         "note": "translates to 'alley'",
         "type": "way"
+    },
+    {
+        "tokens": [
+            "numurs",
+            "nr",
+            "no"
+        ],
+        "full": "numurs",
+        "canonical": "no",
+        "note": "translates to 'nummber'"
+    },
+    {
+        "tokens": [
+            "iela"
+        ],
+        "full": "iela",
+        "canonical": "iela",
+        "note": "translates to 'street'",
+        "type": "way"
+    },
+    {
+        "tokens": [
+            "prospekts"
+        ],
+        "full": "prospekts",
+        "canonical": "prospekts",
+        "note": "translates to 'avenue'",
+        "type": "way"
     }
 ]


### PR DESCRIPTION
Add tokens for Latvia. Source: [libpostal](https://github.com/openvenues/libpostal/tree/master/resources/dictionaries/lv)