### PR TITLE
Update Swedish regexes

### DIFF
--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -27,16 +27,5 @@
         "full": "numurs",
         "canonical": "no",
         "note": "translates to 'nummber'"
-    },
-    {
-        "tokens": [
-            "$1",
-            "([^ ]+)(gatan)"
-        ],
-        "full": "([^ ]+)(gatan)",
-        "canonical": "$1",
-        "regex": true,
-        "skipDiacriticStripping": true,
-        "spanBoundaries": 0    
     }
 ]

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -27,5 +27,16 @@
         "full": "numurs",
         "canonical": "no",
         "note": "translates to 'nummber'"
+    },
+    {
+        "tokens": [
+            "$1",
+            "([^ ]+)(gatan)"
+        ],
+        "full": "([^ ]+)(gatan)",
+        "canonical": "$1",
+        "regex": true,
+        "skipDiacriticStripping": true,
+        "spanBoundaries": 0    
     }
 ]

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -1,10 +1,10 @@
 [
     {
         "tokens": [
-            "$1v",
+            "${1}v",
             "(.+)vägen$"
         ],
-        "full": "(.+)vägen",
+        "full": "(.+)vägen$",
         "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
@@ -13,10 +13,10 @@
     },
     {
         "tokens": [
-            "$1v",
+            "${1}v",
             "(.+)väg$"
         ],
-        "full": "(.+)väg",
+        "full": "(.+)väg$",
         "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
@@ -25,10 +25,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gatan$"
         ],
-        "full": "(.+)gatan",
+        "full": "(.+)gatan$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
@@ -37,10 +37,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gata$"
         ],
-        "full": "(.+)gata",
+        "full": "(.+)gata$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
@@ -49,10 +49,10 @@
     },
     {
         "tokens": [
-            "$1gr",
+            "${1}gr",
             "(.+)gränd$"
         ],
-        "full": "(.+)gränd",
+        "full": "(.+)gränd$",
         "canonical": "${1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
@@ -61,10 +61,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gränden$"
         ],
-        "full": "(.+)gränden",
+        "full": "(.+)gränden$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "{$1}v",
+        "canonical": "{1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "{$1}v",
+        "canonical": "{1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "{$1}gr",
+        "canonical": "{1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "$1v",
+        "canonical": "{$1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "$1v",
+        "canonical": "{$1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "$1gr",
+        "canonical": "{$1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "{1}v",
+        "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "{1}v",
+        "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "{1}gr",
+        "canonical": "${1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -2,7 +2,7 @@
     {
         "tokens": [
             "$1v",
-            "(.+)vägen"
+            "(.+)vägen$"
         ],
         "full": "(.+)vägen",
         "canonical": "$1v",
@@ -14,7 +14,7 @@
     {
         "tokens": [
             "$1v",
-            "(.+)väg"
+            "(.+)väg$"
         ],
         "full": "(.+)väg",
         "canonical": "$1v",
@@ -26,7 +26,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gatan"
+            "(.+)gatan$"
         ],
         "full": "(.+)gatan",
         "canonical": "$1g",
@@ -38,7 +38,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gata"
+            "(.+)gata$"
         ],
         "full": "(.+)gata",
         "canonical": "$1g",
@@ -50,7 +50,7 @@
     {
         "tokens": [
             "$1gr",
-            "(.+)gränd"
+            "(.+)gränd$"
         ],
         "full": "(.+)gränd",
         "canonical": "$1gr",
@@ -62,7 +62,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gränden"
+            "(.+)gränden$"
         ],
         "full": "(.+)gränden",
         "canonical": "$1g",


### PR DESCRIPTION
In Sweden we were getting unexpected network to address matches.

- Eyragatan was matching to a nearby Rudbecksgatan
- We had a regex of full: `(.+)gata` | canonical: `$1g`. What that would do for these two names is strip out the `Eyragata` and `Rudbecksgata`, leaving just `n` which is considered a cardinal for north. 
- With these changes we will make sure the regex goes to the end of the line (so that the full word will match `(.+)gatan$` and the replacement will look up the correct capture group so that the intended letter is kept (originally `$1g` would look up the capture group named 1g and not the capture group at index 1.