### PR TITLE
Sweden Token Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 # Version History
 
+## 4.6.9
+
+- :bug: Fix a regex bug in Sweden(SV).
+
 ## 4.6.8
 
 - :rocket: Token additions for Greece(EL), Croatia (HR), Bosnia and Herzegovina (BA) and Cyprus (CY).
+
 ## 4.6.6
 
 - :rocket: Token additions for Bulgaria(BG).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -27,16 +27,5 @@
         "full": "numurs",
         "canonical": "no",
         "note": "translates to 'nummber'"
-    },
-    {
-        "tokens": [
-            "$1",
-            "([^ ]+)(gatan)"
-        ],
-        "full": "([^ ]+)(gatan)",
-        "canonical": "$1",
-        "regex": true,
-        "skipDiacriticStripping": true,
-        "spanBoundaries": 0    
     }
 ]

--- a/tokens/lv.json
+++ b/tokens/lv.json
@@ -27,5 +27,16 @@
         "full": "numurs",
         "canonical": "no",
         "note": "translates to 'nummber'"
+    },
+    {
+        "tokens": [
+            "$1",
+            "([^ ]+)(gatan)"
+        ],
+        "full": "([^ ]+)(gatan)",
+        "canonical": "$1",
+        "regex": true,
+        "skipDiacriticStripping": true,
+        "spanBoundaries": 0    
     }
 ]

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -1,11 +1,11 @@
 [
     {
         "tokens": [
-            "${1}v",
+            "$1v",
             "(.+)vägen$"
         ],
         "full": "(.+)vägen$",
-        "canonical": "${1}v",
+        "canonical": "$1v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -13,11 +13,11 @@
     },
     {
         "tokens": [
-            "${1}v",
+            "$1v",
             "(.+)väg$"
         ],
         "full": "(.+)väg$",
-        "canonical": "${1}v",
+        "canonical": "$1v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -25,11 +25,11 @@
     },
     {
         "tokens": [
-            "${1}g",
+            "$1g",
             "(.+)gatan$"
         ],
         "full": "(.+)gatan$",
-        "canonical": "${1}g",
+        "canonical": "$1g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -37,11 +37,11 @@
     },
     {
         "tokens": [
-            "${1}g",
+            "$1g",
             "(.+)gata$"
         ],
         "full": "(.+)gata$",
-        "canonical": "${1}g",
+        "canonical": "$1g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -49,11 +49,11 @@
     },
     {
         "tokens": [
-            "${1}gr",
+            "$1gr",
             "(.+)gränd$"
         ],
         "full": "(.+)gränd$",
-        "canonical": "${1}gr",
+        "canonical": "$1gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -61,11 +61,11 @@
     },
     {
         "tokens": [
-            "${1}g",
+            "$1g",
             "(.+)gränden$"
         ],
         "full": "(.+)gränden$",
-        "canonical": "${1}g",
+        "canonical": "$1g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -1,10 +1,10 @@
 [
     {
         "tokens": [
-            "$1v",
+            "${1}v",
             "(.+)vägen$"
         ],
-        "full": "(.+)vägen",
+        "full": "(.+)vägen$",
         "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
@@ -13,10 +13,10 @@
     },
     {
         "tokens": [
-            "$1v",
+            "${1}v",
             "(.+)väg$"
         ],
-        "full": "(.+)väg",
+        "full": "(.+)väg$",
         "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
@@ -25,10 +25,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gatan$"
         ],
-        "full": "(.+)gatan",
+        "full": "(.+)gatan$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
@@ -37,10 +37,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gata$"
         ],
-        "full": "(.+)gata",
+        "full": "(.+)gata$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
@@ -49,10 +49,10 @@
     },
     {
         "tokens": [
-            "$1gr",
+            "${1}gr",
             "(.+)gränd$"
         ],
-        "full": "(.+)gränd",
+        "full": "(.+)gränd$",
         "canonical": "${1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
@@ -61,10 +61,10 @@
     },
     {
         "tokens": [
-            "$1g",
+            "${1}g",
             "(.+)gränden$"
         ],
-        "full": "(.+)gränden",
+        "full": "(.+)gränden$",
         "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "{$1}v",
+        "canonical": "{1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "{$1}v",
+        "canonical": "{1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "{$1}gr",
+        "canonical": "{1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "{$1}g",
+        "canonical": "{1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -65,7 +65,7 @@
             "(.+g)(?:ränden)$"
         ],
         "full": "(.+g)(?:ränden)$",
-        "canonical": "$1g",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "$1v",
+        "canonical": "{$1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "$1v",
+        "canonical": "{$1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "$1gr",
+        "canonical": "{$1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "$1g",
+        "canonical": "{$1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -5,7 +5,7 @@
             "(.+)vägen$"
         ],
         "full": "(.+)vägen",
-        "canonical": "{1}v",
+        "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -17,7 +17,7 @@
             "(.+)väg$"
         ],
         "full": "(.+)väg",
-        "canonical": "{1}v",
+        "canonical": "${1}v",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -29,7 +29,7 @@
             "(.+)gatan$"
         ],
         "full": "(.+)gatan",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -41,7 +41,7 @@
             "(.+)gata$"
         ],
         "full": "(.+)gata",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -53,7 +53,7 @@
             "(.+)gränd$"
         ],
         "full": "(.+)gränd",
-        "canonical": "{1}gr",
+        "canonical": "${1}gr",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -65,7 +65,7 @@
             "(.+)gränden$"
         ],
         "full": "(.+)gränden",
-        "canonical": "{1}g",
+        "canonical": "${1}g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -2,7 +2,7 @@
     {
         "tokens": [
             "$1v",
-            "(.+)vägen"
+            "(.+)vägen$"
         ],
         "full": "(.+)vägen",
         "canonical": "$1v",
@@ -14,7 +14,7 @@
     {
         "tokens": [
             "$1v",
-            "(.+)väg"
+            "(.+)väg$"
         ],
         "full": "(.+)väg",
         "canonical": "$1v",
@@ -26,7 +26,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gatan"
+            "(.+)gatan$"
         ],
         "full": "(.+)gatan",
         "canonical": "$1g",
@@ -38,7 +38,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gata"
+            "(.+)gata$"
         ],
         "full": "(.+)gata",
         "canonical": "$1g",
@@ -50,7 +50,7 @@
     {
         "tokens": [
             "$1gr",
-            "(.+)gränd"
+            "(.+)gränd$"
         ],
         "full": "(.+)gränd",
         "canonical": "$1gr",
@@ -62,7 +62,7 @@
     {
         "tokens": [
             "$1g",
-            "(.+)gränden"
+            "(.+)gränden$"
         ],
         "full": "(.+)gränden",
         "canonical": "$1g",

--- a/tokens/sv.json
+++ b/tokens/sv.json
@@ -1,11 +1,11 @@
 [
     {
         "tokens": [
-            "$1v",
-            "(.+)vägen$"
+            "$1",
+            "(.+v)(?:ägen)$"
         ],
-        "full": "(.+)vägen$",
-        "canonical": "$1v",
+        "full": "(.+v)(?:ägen)$",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -13,11 +13,11 @@
     },
     {
         "tokens": [
-            "$1v",
-            "(.+)väg$"
+            "$1",
+            "(.+v)(?:äg)$"
         ],
-        "full": "(.+)väg$",
-        "canonical": "$1v",
+        "full": "(.+v)(?:äg)$",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'way'",
         "type": "way",
@@ -25,11 +25,11 @@
     },
     {
         "tokens": [
-            "$1g",
-            "(.+)gatan$"
+            "$1",
+            "(.+g)(?:atan)$"
         ],
-        "full": "(.+)gatan$",
-        "canonical": "$1g",
+        "full": "(.+g)(?:atan)$",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -37,11 +37,11 @@
     },
     {
         "tokens": [
-            "$1g",
-            "(.+)gata$"
+            "$1",
+            "(.+g)(?:ata)$"
         ],
-        "full": "(.+)gata$",
-        "canonical": "$1g",
+        "full": "(.+g)(?:ata)$",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'street'",
         "type": "way",
@@ -49,11 +49,11 @@
     },
     {
         "tokens": [
-            "$1gr",
-            "(.+)gränd$"
+            "$1",
+            "(.+gr)(?:änd)$"
         ],
-        "full": "(.+)gränd$",
-        "canonical": "$1gr",
+        "full": "(.+gr)(?:änd)$",
+        "canonical": "$1",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",
         "type": "way",
@@ -61,10 +61,10 @@
     },
     {
         "tokens": [
-            "$1g",
-            "(.+)gränden$"
+            "$1",
+            "(.+g)(?:ränden)$"
         ],
-        "full": "(.+)gränden$",
+        "full": "(.+g)(?:ränden)$",
         "canonical": "$1g",
         "onlyLayers": ["address"],
         "note": "translates to 'alley'",


### PR DESCRIPTION
Continue Ilissa's work to fix the token regex. The `${1}` works differently in Rust and js, so that if we use [`${1}g`, `(.+)gatan$`], carmen will replace "Smalandsgatan" -> "${1}g", rather than "Smalandsgatan" -> "Smalandsg". New token use [`$1`, `(.+g)(?:atan)$`] instead.