### PR TITLE
Only use number abbreviations during processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## 4.6.10
+
+- :rocket: Reduced scope of Spanish and French number tokens.
+
 ## 4.6.9
 
 - :bug: Fix a regex bug in Sweden(SV).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.9",
+  "version": "4.6.10",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/es.json
+++ b/tokens/es.json
@@ -8,7 +8,8 @@
         ],
         "full": "uno",
         "canonical": "1",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -17,7 +18,8 @@
         ],
         "full": "dos",
         "canonical": "2",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -26,7 +28,8 @@
         ],
         "full": "tres",
         "canonical": "3",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -36,7 +39,8 @@
         ],
         "full": "cuatro",
         "canonical": "4",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -46,7 +50,8 @@
         ],
         "full": "cinco",
         "canonical": "5",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -56,7 +61,8 @@
         ],
         "full": "seis",
         "canonical": "6",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -66,7 +72,8 @@
         ],
         "full": "siete",
         "canonical": "7",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -76,7 +83,8 @@
         ],
         "full": "ocho",
         "canonical": "8",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -86,7 +94,8 @@
         ],
         "full": "nueve",
         "canonical": "9",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -96,7 +105,8 @@
         ],
         "full": "diez",
         "canonical": "10",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -106,7 +116,8 @@
         ],
         "full": "once",
         "canonical": "11",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -116,7 +127,8 @@
         ],
         "full": "doce",
         "canonical": "12",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -126,7 +138,8 @@
         ],
         "full": "trece",
         "canonical": "13",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -136,7 +149,8 @@
         ],
         "full": "catorce",
         "canonical": "14",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -146,7 +160,8 @@
         ],
         "full": "quince",
         "canonical": "15",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -156,7 +171,8 @@
         ],
         "full": "dieciseis",
         "canonical": "16",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -166,7 +182,8 @@
         ],
         "full": "diecisiete",
         "canonical": "17",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -176,7 +193,8 @@
         ],
         "full": "dieciocho",
         "canonical": "18",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -186,7 +204,8 @@
         ],
         "full": "diecinueve",
         "canonical": "19",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -196,7 +215,8 @@
         ],
         "full": "veinte",
         "canonical": "20",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -6,7 +6,8 @@
         ],
         "full": "zero",
         "canonical": "0",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -16,7 +17,8 @@
         ],
         "full": "une",
         "canonical": "1",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -25,7 +27,8 @@
         ],
         "full": "deux",
         "canonical": "2",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -34,7 +37,8 @@
         ],
         "full": "trois",
         "canonical": "3",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -44,7 +48,8 @@
         ],
         "full": "quatre",
         "canonical": "4",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -53,7 +58,8 @@
         ],
         "full": "cinq",
         "canonical": "5",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -62,7 +68,8 @@
         ],
         "full": "six",
         "canonical": "6",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -71,7 +78,8 @@
         ],
         "full": "sept",
         "canonical": "7",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -80,7 +88,8 @@
         ],
         "full": "huit",
         "canonical": "8",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -89,7 +98,8 @@
         ],
         "full": "neuf",
         "canonical": "9",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -98,7 +108,8 @@
         ],
         "full": "dix",
         "canonical": "10",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -107,7 +118,8 @@
         ],
         "full": "onze",
         "canonical": "11",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -116,7 +128,8 @@
         ],
         "full": "douze",
         "canonical": "12",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -125,7 +138,8 @@
         ],
         "full": "treize",
         "canonical": "13",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -134,7 +148,8 @@
         ],
         "full": "quatorze",
         "canonical": "14",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -143,7 +158,8 @@
         ],
         "full": "quinze",
         "canonical": "15",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -152,7 +168,8 @@
         ],
         "full": "seize",
         "canonical": "16",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -162,7 +179,8 @@
         "full": "dix sept",
         "canonical": "17",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -172,7 +190,8 @@
         "full": "dix huit",
         "canonical": "18",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -182,7 +201,8 @@
         "full": "dix neuf",
         "canonical": "19",
         "type": "number",
-        "spanBoundaries": 1
+        "spanBoundaries": 1,
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [
@@ -191,7 +211,8 @@
         ],
         "full": "twenty",
         "canonical": "20",
-        "type": "number"
+        "type": "number",
+        "onlyUseWhile": ["processing"]
     },
     {
         "tokens": [


### PR DESCRIPTION
Spanish and French number tokens were initially added for processing purposes only, and haven't been thoroughly tested for indexing/querying. This PR applies the `onlyUseWhile` tag to each to them to limit their scope.

@mapbox/search-addresses 