### PR TITLE
Canada postcode regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## 4.6.14
 
+- :rocket: Update regex for Canada in English and add in regex in French.
+## 4.6.14
+
 - :bug: Fix country code for Poland postcode regex.
 
 ## 4.6.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 # Version History
 
-## 4.6.14
+## 4.6.15
 
 - :rocket: Update regex for Canada in English and add in regex in French.
 ## 4.6.14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/geocoder-abbreviations",
-  "version": "4.6.14",
+  "version": "4.6.15",
   "description": "Language/Country Specific Street Abbreviations",
   "main": "index.js",
   "scripts": {

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -3012,7 +3012,7 @@
         "full": "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)",
         "canonical": "$1$2",
         "onlyCountries": ["ca"],
-        "onlyLayers": ["address"],
+        "onlyLayers": ["postcode"],
         "spanBoundaries": 1,
         "note": "normalize postal code",
         "regex": true

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -3012,7 +3012,7 @@
         "full": "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)",
         "canonical": "$1$2",
         "onlyCountries": ["ca"],
-        "onlyLayers": ["postcode"],
+        "onlyLayers": ["address"],
         "spanBoundaries": 1,
         "note": "normalize postal code",
         "regex": true

--- a/tokens/en.json
+++ b/tokens/en.json
@@ -3007,9 +3007,9 @@
     {
         "tokens": [
             "$1$2",
-            "([0-9A-Z]{3}) ?([0-9A-Z]{3})"
+            "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)"
         ],
-        "full": "([0-9A-Z]{3}) ?([0-9A-Z]{3})",
+        "full": "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)",
         "canonical": "$1$2",
         "onlyCountries": ["ca"],
         "onlyLayers": ["address"],

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -1340,5 +1340,18 @@
         "canonical": "$1$2",
         "regex": true,
         "spanBoundaries": 1
+    },
+    {
+        "tokens": [
+            "$1$2",
+            "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)"
+        ],
+        "full": "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)",
+        "canonical": "$1$2",
+        "onlyCountries": ["ca"],
+        "onlyLayers": ["postcode"],
+        "spanBoundaries": 1,
+        "note": "normalize postal code",
+        "regex": true
     }
 ]

--- a/tokens/fr.json
+++ b/tokens/fr.json
@@ -1349,7 +1349,7 @@
         "full": "([A-Z]\\d[A-Z]) ?(\\d[A-Z]\\d)",
         "canonical": "$1$2",
         "onlyCountries": ["ca"],
-        "onlyLayers": ["postcode"],
+        "onlyLayers": ["address"],
         "spanBoundaries": 1,
         "note": "normalize postal code",
         "regex": true


### PR DESCRIPTION
Update postcode regex for Canada for both the English and French language.

cc @mapbox/search-addresses 